### PR TITLE
explicit font-size for tutorial_instructions

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -90,6 +90,7 @@ main.tutorial {
 
 #tutorial_instructions {
     margin: 1rem;
+    font-size: large;
 }
 
 #tutorial_canvas {


### PR DESCRIPTION
From mobile the instructions in the tutorial get displayed too big. This is an attempt at fixing it by making an explicit text-size rule.